### PR TITLE
Add plugin to turn aftertouch into CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ patch:
 plugins: libs
 	$(MAKE) all -C plugins/MIDICCRecorder
 	$(MAKE) all -C plugins/MIDIPBToCC
+	$(MAKE) all -C plugins/MIDIPressureToCC
 	$(MAKE) all -C plugins/MIDISysFilter
 
 ifneq ($(CROSS_COMPILING),true)
@@ -46,17 +47,20 @@ clean:
 	$(MAKE) clean -C dpf/utils/lv2-ttl-generator
 	$(MAKE) clean -C plugins/MIDICCRecorder
 	$(MAKE) clean -C plugins/MIDIPBToCC
+	$(MAKE) clean -C plugins/MIDIPressureToCC
 	$(MAKE) clean -C plugins/MIDISysFilter
 	rm -rf bin build
 
 install: all
 	$(MAKE) install -C plugins/MIDICCRecorder
 	$(MAKE) install -C plugins/MIDIPBToCC
+	$(MAKE) install -C plugins/MIDIPressureToCC
 	$(MAKE) install -C plugins/MIDISysFilter
 
 install-user: all
 	$(MAKE) install-user -C plugins/MIDICCRecorder
 	$(MAKE) install-user -C plugins/MIDIPBToCC
+	$(MAKE) install-user -C plugins/MIDIPressureToCC
 	$(MAKE) install-user -C plugins/MIDISysFilter
 
 # --------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ Convert Pitch Bend into Control Change messages
   well (useful, for example, to cascade several instances of this plugin).
 
 
+### MIDI PressureToCC
+
+Convert (monophonic) Channel Pressure (Aftertouch) into Control Change
+messages 
+
+![MIDI PressureToCC screenshot](screenshots/MIDIPressureToCC.png)
+
+* Can act on all MIDI channels or a specific one.
+* Configurable destination controller (0-127): modulation, breath, expression,
+  etc.
+* Any unconverted messages are kept in the plugin's output.
+* Original Channel Pressure messages can be optionally kept as well (useful,
+  for example, to cascade several instances of this plugin).
+
+
 ### MIDI SysFilter
 
 A filter for MIDI System Messages

--- a/plugins/MIDIPressureToCC/DistrhoPluginInfo.h
+++ b/plugins/MIDIPressureToCC/DistrhoPluginInfo.h
@@ -1,0 +1,46 @@
+/*
+ * MIDI PBToCC plugin based on DISTRHO Plugin Framework (DPF)
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef DISTRHO_PLUGIN_INFO_H
+#define DISTRHO_PLUGIN_INFO_H
+
+#define DISTRHO_PLUGIN_BRAND        "chrisarndt.de"
+#define DISTRHO_PLUGIN_NAME         "MIDI Channel Pressure (Aftertouch) to CC"
+#define DISTRHO_PLUGIN_URI          "https://chrisarndt.de/plugins/midipressuretocc"
+#define DISTRHO_PLUGIN_LV2_CATEGORY "lv2:MIDIPlugin"
+
+#define DISTRHO_PLUGIN_HAS_UI       0
+#define DISTRHO_UI_USE_NANOVG       0
+
+#define DISTRHO_PLUGIN_IS_RT_SAFE       1
+#define DISTRHO_PLUGIN_NUM_INPUTS       0
+#define DISTRHO_PLUGIN_NUM_OUTPUTS      0
+#define DISTRHO_PLUGIN_WANT_TIMEPOS     0
+#define DISTRHO_PLUGIN_WANT_PROGRAMS    1
+#define DISTRHO_PLUGIN_WANT_MIDI_INPUT  1
+#define DISTRHO_PLUGIN_WANT_MIDI_OUTPUT 1
+
+#endif // DISTRHO_PLUGIN_INFO_H

--- a/plugins/MIDIPressureToCC/DistrhoPluginInfo.h
+++ b/plugins/MIDIPressureToCC/DistrhoPluginInfo.h
@@ -1,9 +1,9 @@
 /*
- * MIDI PBToCC plugin based on DISTRHO Plugin Framework (DPF)
+ * MIDI PressureToCC plugin based on DISTRHO Plugin Framework (DPF)
  *
  * SPDX-License-Identifier: MIT
  *
- * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>
+ * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>, Jorik Jonker <jorik@kippendief.biz>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -28,7 +28,7 @@
 #define DISTRHO_PLUGIN_INFO_H
 
 #define DISTRHO_PLUGIN_BRAND        "chrisarndt.de"
-#define DISTRHO_PLUGIN_NAME         "MIDI Channel Pressure (Aftertouch) to CC"
+#define DISTRHO_PLUGIN_NAME         "MIDI Pressure to CC"
 #define DISTRHO_PLUGIN_URI          "https://chrisarndt.de/plugins/midipressuretocc"
 #define DISTRHO_PLUGIN_LV2_CATEGORY "lv2:MIDIPlugin"
 

--- a/plugins/MIDIPressureToCC/Makefile
+++ b/plugins/MIDIPressureToCC/Makefile
@@ -1,0 +1,118 @@
+#!/usr/bin/make -f
+# Makefile for DISTRHO Plugins #
+# ---------------------------- #
+# Created by falkTX, Christopher Arndt, and Patrick Desaulniers
+#
+
+# --------------------------------------------------------------
+# Installation directories
+
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+LIBDIR ?= $(PREFIX)/lib
+DSSI_DIR ?= $(LIBDIR)/dssi
+LADSPA_DIR ?= $(LIBDIR)/ladspa
+LV2_DIR ?= $(LIBDIR)/lv2
+VST_DIR ?= $(LIBDIR)/vst
+
+# --------------------------------------------------------------
+# Project name, used for binaries
+
+NAME = midipressuretocc
+
+# --------------------------------------------------------------
+# Plugin types to build
+
+BUILD_LV2 ?= true
+BUILD_VST2 ?= true
+BUILD_JACK ?= false
+BUILD_DSSI ?= false
+BUILD_LADSPA ?= false
+
+# --------------------------------------------------------------
+# Files to build
+
+FILES_DSP = \
+	PluginMIDIPressureToCC.cpp
+
+# --------------------------------------------------------------
+# Do some magic
+
+include ../../dpf/Makefile.plugins.mk
+
+# --------------------------------------------------------------
+# Enable all selected plugin types
+
+ifeq ($(BUILD_LV2),true)
+ifeq ($(HAVE_DGL),true)
+TARGETS += lv2_sep
+else
+TARGETS += lv2_dsp
+endif
+endif
+
+ifeq ($(BUILD_VST2),true)
+TARGETS += vst
+endif
+
+ifeq ($(BUILD_JACK),true)
+ifeq ($(HAVE_JACK),true)
+TARGETS += jack
+endif
+endif
+
+ifeq ($(BUILD_DSSI),true)
+ifeq ($(HAVE_DGL),true)
+ifeq ($(HAVE_LIBLO),true)
+TARGETS += dssi
+endif
+endif
+endif
+
+ifeq ($(BUILD_LADSPA),true)
+TARGETS += ladspa
+endif
+
+all: $(TARGETS)
+
+install: all
+ifeq ($(BUILD_DSSI),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-dssi$(LIB_EXT) -t $(DESTDIR)$(DSSI_DIR)
+endif
+ifeq ($(BUILD_LADSPA),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-ladspa$(LIB_EXT) -t $(DESTDIR)$(LADSPA_DIR)
+endif
+ifeq ($(BUILD_VST2),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-vst$(LIB_EXT) -t $(DESTDIR)$(VST_DIR)
+endif
+ifeq ($(BUILD_LV2),true)
+	@install -dm755 $(DESTDIR)$(LV2_DIR) && \
+		cp -rf $(TARGET_DIR)/$(NAME).lv2 $(DESTDIR)$(LV2_DIR)
+endif
+ifeq ($(BUILD_JACK),true)
+ifeq ($(HAVE_JACK),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)$(APP_EXT) -t $(DESTDIR)$(BINDIR)
+endif
+endif
+
+install-user: all
+ifeq ($(BUILD_DSSI),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-dssi$(LIB_EXT) -t $(HOME)/.dssi
+endif
+ifeq ($(BUILD_LADSPA),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-ladspa$(LIB_EXT) -t $(HOME)/.ladspa
+endif
+ifeq ($(BUILD_VST2),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)-vst$(LIB_EXT) -t $(HOME)/.vst
+endif
+ifeq ($(BUILD_LV2),true)
+	@install -dm755 $(HOME)/.lv2 && \
+		cp -rf $(TARGET_DIR)/$(NAME).lv2 $(HOME)/.lv2
+endif
+ifeq ($(BUILD_JACK),true)
+	@install -Dm755 $(TARGET_DIR)/$(NAME)$(APP_EXT) -t $(HOME)/bin
+endif
+
+# --------------------------------------------------------------
+
+.PHONY: all install install-user

--- a/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.cpp
+++ b/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.cpp
@@ -1,5 +1,5 @@
 /*
- * MIDI PBToCC plugin based on DISTRHO Plugin Framework (DPF)
+ * MIDI PressureToCC plugin based on DISTRHO Plugin Framework (DPF)
  *
  * SPDX-License-Identifier: MIT
  *
@@ -103,9 +103,9 @@ void PluginMIDIPressureToCC::initParameter(uint32_t index, Parameter& parameter)
             parameter.hints |= kParameterIsBoolean;
             parameter.ranges.max = 1;
             break;
-        case paramCC:
-            parameter.name = "Target CC";
-            parameter.symbol = "cc";
+        case paramDestCC:
+            parameter.name = "Destination CC";
+            parameter.symbol = "dest_cc";
             parameter.ranges.def = 1;
             break;
    }
@@ -150,7 +150,7 @@ void PluginMIDIPressureToCC::setParameterValue(uint32_t index, float value) {
         case paramKeepOriginal:
             fParams[index] = CLAMP(value, 0.0f, 1.0f);
             break;
-        case paramCC:
+        case paramDestCC:
             fParams[index] = CLAMP(value, 0.0f, 127.0f);
             break;
     }
@@ -179,7 +179,7 @@ void PluginMIDIPressureToCC::activate() {
 
 
 void PluginMIDIPressureToCC::run(const float**, float**, uint32_t,
-                           const MidiEvent* events, uint32_t eventCount) {
+                                 const MidiEvent* events, uint32_t eventCount) {
     uint8_t chan;
     struct MidiEvent cc_event;
 
@@ -194,8 +194,8 @@ void PluginMIDIPressureToCC::run(const float**, float**, uint32_t,
         if (filterChannel == -1 || chan == filterChannel) {
             cc_event.frame = events[i].frame;
             cc_event.size = 3;
-	    cc_event.data[0] = MIDI_CONTROL_CHANGE | chan;
-            cc_event.data[1] = (uint8_t) fParams[paramCC];
+            cc_event.data[0] = MIDI_CONTROL_CHANGE | chan;
+            cc_event.data[1] = (uint8_t) fParams[paramDestCC];
             cc_event.data[2] = events[i].data[1] & 0x7f;
             writeMidiEvent(cc_event);
         }

--- a/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.cpp
+++ b/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.cpp
@@ -1,0 +1,214 @@
+/*
+ * MIDI PBToCC plugin based on DISTRHO Plugin Framework (DPF)
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "PluginMIDIPressureToCC.hpp"
+
+START_NAMESPACE_DISTRHO
+
+// -----------------------------------------------------------------------
+
+PluginMIDIPressureToCC::PluginMIDIPressureToCC()
+    : Plugin(paramCount, presetCount, 0)  // 0 states
+{
+    loadProgram(0);
+}
+
+// -----------------------------------------------------------------------
+// Init
+
+void PluginMIDIPressureToCC::initParameter(uint32_t index, Parameter& parameter) {
+    if (index >= paramCount)
+        return;
+
+    parameter.hints = kParameterIsAutomable | kParameterIsInteger;
+    parameter.ranges.def = 0;
+    parameter.ranges.min = 0;
+    parameter.ranges.max = 127;
+
+    switch (index) {
+        case paramFilterChannel:
+            parameter.name = "Filter Channel";
+            parameter.symbol = "channelf";
+            parameter.ranges.def = 0;
+            parameter.ranges.min = 0;
+            parameter.ranges.max = 16;
+            parameter.enumValues.count = 17;
+            parameter.enumValues.restrictedMode = true;
+            {
+                ParameterEnumerationValue* const channels = new ParameterEnumerationValue[17];
+                parameter.enumValues.values = channels;
+                channels[0].label = "Any";
+                channels[0].value = 0;
+                channels[1].label = "Channel 1";
+                channels[1].value = 1;
+                channels[2].label = "Channel 2";
+                channels[2].value = 2;
+                channels[3].label = "Channel 3";
+                channels[3].value = 3;
+                channels[4].label = "Channel 4";
+                channels[4].value = 4;
+                channels[5].label = "Channel 5";
+                channels[5].value = 5;
+                channels[6].label = "Channel 6";
+                channels[6].value = 6;
+                channels[7].label = "Channel 7";
+                channels[7].value = 7;
+                channels[8].label = "Channel 8";
+                channels[8].value = 8;
+                channels[9].label = "Channel 9";
+                channels[9].value = 9;
+                channels[10].label = "Channel 10";
+                channels[10].value = 10;
+                channels[11].label = "Channel 11";
+                channels[11].value = 11;
+                channels[12].label = "Channel 12";
+                channels[12].value = 12;
+                channels[13].label = "Channel 13";
+                channels[13].value = 13;
+                channels[14].label = "Channel 14";
+                channels[14].value = 14;
+                channels[15].label = "Channel 15";
+                channels[15].value = 15;
+                channels[16].label = "Channel 16";
+                channels[16].value = 16;
+            }
+            break;
+        case paramKeepOriginal:
+            parameter.name = "Keep original Pressure events";
+            parameter.shortName = "Keep original";
+            parameter.symbol = "keep_original";
+            parameter.hints |= kParameterIsBoolean;
+            parameter.ranges.max = 1;
+            break;
+        case paramCC:
+            parameter.name = "Target CC";
+            parameter.symbol = "cc";
+            parameter.ranges.def = 1;
+            break;
+   }
+}
+
+/**
+  Set the name of the program @a index.
+  This function will be called once, shortly after the plugin is created.
+*/
+void PluginMIDIPressureToCC::initProgramName(uint32_t index, String& programName) {
+    if (index < presetCount) {
+        programName = factoryPresets[index].name;
+    }
+}
+
+// -----------------------------------------------------------------------
+// Internal data
+
+/**
+  Optional callback to inform the plugin about a sample rate change.
+*/
+void PluginMIDIPressureToCC::sampleRateChanged(double newSampleRate) {
+    (void) newSampleRate;
+}
+
+/**
+  Get the current value of a parameter.
+*/
+float PluginMIDIPressureToCC::getParameterValue(uint32_t index) const {
+    return fParams[index];
+}
+
+/**
+  Change a parameter value.
+*/
+void PluginMIDIPressureToCC::setParameterValue(uint32_t index, float value) {
+    switch (index) {
+        case paramFilterChannel:
+            fParams[index] = CLAMP(value, 0.0f, 16.0f);
+            filterChannel = (int8_t) fParams[index] - 1;
+            break;
+        case paramKeepOriginal:
+            fParams[index] = CLAMP(value, 0.0f, 1.0f);
+            break;
+        case paramCC:
+            fParams[index] = CLAMP(value, 0.0f, 127.0f);
+            break;
+    }
+}
+
+/**
+  Load a program.
+  The host may call this function from any context,
+  including realtime processing.
+*/
+void PluginMIDIPressureToCC::loadProgram(uint32_t index) {
+    if (index < presetCount) {
+        for (int i=0; i < paramCount; i++) {
+            setParameterValue(i, factoryPresets[index].params[i]);
+        }
+
+    }
+}
+
+// -----------------------------------------------------------------------
+// Process
+
+void PluginMIDIPressureToCC::activate() {
+    // plugin is activated
+}
+
+
+void PluginMIDIPressureToCC::run(const float**, float**, uint32_t,
+                           const MidiEvent* events, uint32_t eventCount) {
+    uint8_t chan;
+    struct MidiEvent cc_event;
+
+    for (uint32_t i=0; i<eventCount; ++i) {
+        if ((events[i].data[0] & 0xF0) != MIDI_CHANNEL_PRESSURE) {
+            writeMidiEvent(events[i]);
+            continue;
+        }
+
+        chan = events[i].data[0] & 0x0F;
+
+        if (filterChannel == -1 || chan == filterChannel) {
+            cc_event.frame = events[i].frame;
+            cc_event.size = 3;
+	    cc_event.data[0] = MIDI_CONTROL_CHANGE | chan;
+            cc_event.data[1] = (uint8_t) fParams[paramCC];
+            cc_event.data[2] = events[i].data[1] & 0x7f;
+            writeMidiEvent(cc_event);
+        }
+        if ((bool) fParams[paramKeepOriginal]) writeMidiEvent(events[i]);
+    }
+}
+
+// -----------------------------------------------------------------------
+
+Plugin* createPlugin() {
+    return new PluginMIDIPressureToCC();
+}
+
+// -----------------------------------------------------------------------
+
+END_NAMESPACE_DISTRHO

--- a/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.hpp
+++ b/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.hpp
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  *
- * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>
+ * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>, Jorik Jonker <jorik@kippendief.biz>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -24,8 +24,8 @@
  * IN THE SOFTWARE.
  */
 
-#ifndef PLUGIN_MIDIPressureTOCC_H
-#define PLUGIN_MIDIPressureTOCC_H
+#ifndef PLUGIN_MIDIPRESSURETOCC_H
+#define PLUGIN_MIDIPRESSURETOCC_H
 
 #include "DistrhoPlugin.hpp"
 
@@ -53,7 +53,7 @@ public:
     enum Parameters {
         paramFilterChannel,
         paramKeepOriginal,
-        paramCC,
+        paramDestCC,
         paramCount
     };
 
@@ -68,7 +68,7 @@ protected:
     }
 
     const char* getDescription() const override {
-        return "Convert Monophonic Channel Pressure (Aftertouch) into Control Change messages";
+        return "Convert monophonic Channel Pressure (Aftertouch) into Control Change messages";
     }
 
     const char* getMaker() const noexcept override {
@@ -84,7 +84,7 @@ protected:
     }
 
     uint32_t getVersion() const noexcept override {
-        return d_version(1, 2, 2);
+        return d_version(1, 0, 0);
     }
 
     // Go to:
@@ -148,6 +148,10 @@ const Preset factoryPresets[] = {
         {0.0, 0.0, 2.0}
     },
     {
+        "Foot Controller",
+        {0.0, 0.0, 4.0}
+    },
+    {
         "Expression",
         {0.0, 0.0, 11.0}
     }
@@ -159,4 +163,4 @@ const uint presetCount = sizeof(factoryPresets) / sizeof(Preset);
 
 END_NAMESPACE_DISTRHO
 
-#endif  // #ifndef PLUGIN_MIDIPressureTOCC_H
+#endif  // #ifndef PLUGIN_MIDIPRESSURETOCC_H

--- a/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.hpp
+++ b/plugins/MIDIPressureToCC/PluginMIDIPressureToCC.hpp
@@ -1,0 +1,162 @@
+/*
+ * MIDI PressureToCC plugin based on DISTRHO Plugin Framework (DPF)
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 Christopher Arndt <info@chrisarndt.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLUGIN_MIDIPressureTOCC_H
+#define PLUGIN_MIDIPressureTOCC_H
+
+#include "DistrhoPlugin.hpp"
+
+START_NAMESPACE_DISTRHO
+
+#ifndef MIN
+#define MIN(a,b) ( (a) < (b) ? (a) : (b) )
+#endif
+
+#ifndef MAX
+#define MAX(a,b) ( (a) > (b) ? (a) : (b) )
+#endif
+
+#ifndef CLAMP
+#define CLAMP(v, min, max) (MIN((max), MAX((min), (v))))
+#endif
+
+#define MIDI_CONTROL_CHANGE 0xB0
+#define MIDI_CHANNEL_PRESSURE 0xD0
+
+// -----------------------------------------------------------------------
+
+class PluginMIDIPressureToCC : public Plugin {
+public:
+    enum Parameters {
+        paramFilterChannel,
+        paramKeepOriginal,
+        paramCC,
+        paramCount
+    };
+
+    PluginMIDIPressureToCC();
+
+protected:
+    // -------------------------------------------------------------------
+    // Information
+
+    const char* getLabel() const noexcept override {
+        return "MIDIPressureToCC";
+    }
+
+    const char* getDescription() const override {
+        return "Convert Monophonic Channel Pressure (Aftertouch) into Control Change messages";
+    }
+
+    const char* getMaker() const noexcept override {
+        return "chrisarndt.de";
+    }
+
+    const char* getHomePage() const override {
+        return "https://chrisarndt.de/plugins/midipressuretocc";
+    }
+
+    const char* getLicense() const noexcept override {
+        return "https://spdx.org/licenses/MIT";
+    }
+
+    uint32_t getVersion() const noexcept override {
+        return d_version(1, 2, 2);
+    }
+
+    // Go to:
+    //
+    // http://service.steinberg.de/databases/plugin.nsf/plugIn
+    //
+    // Get a proper plugin UID and fill it in here!
+    int64_t getUniqueId() const noexcept override {
+        return d_cconst('M', 'A', 't', 'C');
+    }
+
+    // -------------------------------------------------------------------
+    // Init
+
+    void initParameter(uint32_t index, Parameter& parameter) override;
+    void initProgramName(uint32_t index, String& programName) override;
+
+    // -------------------------------------------------------------------
+    // Internal data
+
+    float getParameterValue(uint32_t index) const override;
+    void setParameterValue(uint32_t index, float value) override;
+    void loadProgram(uint32_t index) override;
+
+    // -------------------------------------------------------------------
+    // Optional
+
+    // Optional callback to inform the plugin about a sample rate change.
+    void sampleRateChanged(double newSampleRate) override;
+
+    // -------------------------------------------------------------------
+    // Process
+
+    void activate() override;
+
+    void run(const float**, float**, uint32_t,
+             const MidiEvent* midiEvents, uint32_t midiEventCount) override;
+
+
+    // -------------------------------------------------------------------
+
+private:
+    float fParams[paramCount];
+    int8_t filterChannel;
+
+    DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginMIDIPressureToCC)
+};
+
+struct Preset {
+    const char* name;
+    const float params[PluginMIDIPressureToCC::paramCount];
+};
+
+const Preset factoryPresets[] = {
+    {
+        "Modulation",
+        {0.0, 0.0, 1.0}
+    },
+    {
+        "Breath",
+        {0.0, 0.0, 2.0}
+    },
+    {
+        "Expression",
+        {0.0, 0.0, 11.0}
+    }
+};
+
+const uint presetCount = sizeof(factoryPresets) / sizeof(Preset);
+
+// -----------------------------------------------------------------------
+
+END_NAMESPACE_DISTRHO
+
+#endif  // #ifndef PLUGIN_MIDIPressureTOCC_H


### PR DESCRIPTION
This plugin turns (monophonic) channel pressure status messages (better known as Aftertouch) into continous controller messages. I use it to turn the aftertouch of my MIDI keyboard into a mod wheel, since a lot of synths do not implement AT.